### PR TITLE
Adjust workflow triggers for publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - work
+  workflow_dispatch:
 
 jobs:
   trigger:


### PR DESCRIPTION
## Summary
- include the work branch in the publishing workflow trigger to ensure pushes from the default branch invoke the pipeline
- allow manual workflow_dispatch runs for troubleshooting the publishing pipe

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68f0f28529c88326b69078ec1bbfc403