### PR TITLE
Add publish workflow for develop pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+      - work
+      - develop
+  workflow_dispatch:
 
 jobs:
   trigger:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: PUBLISH
+
+on:
+  pull_request:
+    branches:
+      - develop
+  workflow_dispatch:
+
+jobs:
+  cd-auth-dot-net:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    uses: vyracare/vyracare-infra-pipes-dot-net/.github/workflows/cd-auth-dot-net.yml@main
+    with:
+      branch-name: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- add a publish workflow that triggers when pull requests target develop or when run manually
- guard against forked pull requests inheriting secrets and compute the branch name using the pull request head

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68f0f28529c88326b69078ec1bbfc403