### PR TITLE
Add AWS Lambda hosting usings

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,3 +1,5 @@
+using Amazon.Lambda.AspNetCoreServer;
+using Amazon.Lambda.AspNetCoreServer.Hosting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using MongoDB.Driver;


### PR DESCRIPTION
## Summary
- add the Amazon Lambda using directives in Program.cs so LambdaEventSource and AddAWSLambdaHosting are available
- ensure Program.cs ends with a trailing newline for proper formatting

## Testing
- ⚠️ `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_690ab0a71c208326898e0ce9d2cbd850